### PR TITLE
redirect from `/instances` to `/instances/new` or `/instances/:someId`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ import {browserHistory} from 'react-router';
 import {syncHistoryWithStore} from 'react-router-redux';
 import makeRouter from './routes';
 const history = syncHistoryWithStore(browserHistory, store);
-const router = makeRouter(history);
+const router = makeRouter(history, store);
 
 render(
 	<Provider store={store}>

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,4 +1,4 @@
-import {Router, Route, IndexRedirect} from 'react-router';
+import {Router, Route, IndexRedirect, IndexRoute} from 'react-router';
 
 import GlobalContainer from 'containers/GlobalContainer';
 
@@ -11,7 +11,23 @@ import InstanceContainer from 'containers/InstanceContainer';
 import ButtonsView from 'components/Buttons/ButtonsView';
 import ButtonContainer from 'containers/ButtonContainer';
 
-export default function makeRouter(history) {
+
+import {getInstances} from 'helpers/selectors';
+
+function redirectIndex(store) {
+	return (nextState, replace) => {
+		let path = 'new';
+
+		const instances = getInstances(store.getState());
+
+		const item = instances && instances.first();
+		if (item) path = item.id;
+
+		replace(`${location.pathname}/${path}`);
+	};
+}
+
+export default function makeRouter(history, store) {
 	return (
 		<Router history={history}>
 			<Route path="/" component={GlobalContainer}>
@@ -25,7 +41,7 @@ export default function makeRouter(history) {
 				</Route>
 
 				<Route path="/instances" component={InstancesView}>
-					<IndexRedirect to="new" />
+					<IndexRoute onEnter={redirectIndex(store)} />
 
 					<Route path="new" component={InstanceContainer} />
 					<Route path=":instanceId" component={InstanceContainer} />


### PR DESCRIPTION
Does this by using the RR `onEnter` hook and fetches all the instances from the store and uses the id of the first one or falls back to `new`.

Doesn't work on initial page load though - which is super important as we always want the user to load into a view that isn't an empty state.

I toyed around with making the `onEnter` hook the async version (by including a third `done` callback argument) and not calling that until the instances had finished loading (had to add a `hasLoaded` field to the reducer) and just hacking in a `setInterval` that made it recheck if it had finished loading. But RR blocks until you call `done` which means that the fetch request isn't ever sent.

So not quite sure how to solve this because it feels wrong and like a hack to do it in an actual component, for example checking in `componentDidX` if the route is an index route and then if there's data and redirecting, if there's not data just waiting until there is because the data should trigger a rerender.